### PR TITLE
Removed cannotBeEmpty() from the Configuration tree

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,7 +33,6 @@ class Configuration implements ConfigurationInterface
                         ->integerNode('ttl')
                             ->min(0)
                             ->isRequired()
-                            ->cannotBeEmpty()
                         ->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
Since Symfony 3.0 the cannotBeEmpty() is removed for an integerNode. For more information see:
https://github.com/symfony/symfony/pull/15170
https://github.com/symfony/symfony/pull/15285