### PR TITLE
Pass root name to the TreeBuilder::root method

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('wb_big_register');
+        $treeBuilder = new TreeBuilder('wb_big_register');
+        $rootNode    = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
This fixes the deprecation message:

> The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "wb_big_register" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.

For more information see: https://github.com/symfony/symfony/pull/31027